### PR TITLE
Invoke an alternative method to create the bucket.

### DIFF
--- a/bin/upload_s3.pl
+++ b/bin/upload_s3.pl
@@ -50,7 +50,7 @@ my $s3 = Amazon::S3->new({
   retry => 0,
   timeout => 5,
 });
-my $bucket = $s3->bucket($bucket_name); 
+my $bucket = $s3->add_bucket({ bucket => $bucket_name }); 
 # use Data::Dumper; warn Dumper ($s3->buckets()); die;
 
 # Find files and upload


### PR DESCRIPTION
I've made some tests with the original "bucket" method but nothing happend on S3. Changing to "add_bucket" seems to have solved the problem.
